### PR TITLE
Add protect option to query parser in place of extra argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,10 @@ Provide a function that takes two arguments:
 
 - `value`: a string potentially representing a number
 - `radix`: 10
-- `name` : a name of query argument
 
 ```js
 app.use(queryParser({
-  parser: function(value, radix, name) {
+  parser: function(value, radix) {
     if (true) {
       return modifiedValue;
     }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ app.use(queryParser({
 }));
 ```
 
+### Protected Keys
+By default the parser will transform any string that resembles a number. Sometimes, though, you'll have a query argument like `id` that you want to stay a string. For cases like this, just pass in a `protect` function - the parser won't be applied for keys where `protect(key)` is true.
+
+```js
+app.use(queryParser({
+  protect: function (key) {
+    return key === 'id';
+  }
+}));
+```
+
 ### Custom Parser
 Provide a function that takes two arguments:
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,17 @@
 var parseNums = require('./lib/parse');
 
 module.exports = function(options) {
-  options = options || {
-    parser: parseInt
-  };
+  options = options || {};
+
+  if (!options.parser) {
+    options.parser = parseInt;
+  }
+
+  if (!options.protect) {
+    options.protect = function () {
+      return false;
+    };
+  }
 
   return function(req, res, next) {
     req.query = parseNums(req.query, options);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -5,6 +5,7 @@
  * @param  {Object}    obj             - Object to iterate over.
  * @param  {Object}    options         - Options.
  * @param  {Function}  options.parser  - Parser to process string with. Should return NaN if not a valid number. Defaults to parseInt.
+ * @param  {Function}  options.protect - Should return true if the key should not be parsed. If not provided, all keys will be parsed.
  * @return {Object}    Returns new object with same properties (shallow copy).
 */
 function parseNums(obj, options) {
@@ -18,7 +19,7 @@ function parseNums(obj, options) {
       value = obj[key];
       parsedValue = options.parser.call(null, value, 10, key);
 
-      if (typeof value === 'string' && !isNaN(parsedValue)) {
+      if (typeof value === 'string' && !options.protect(key) && !isNaN(parsedValue)) {
         result[key] = parsedValue;
       }
       else if (value.constructor === Object) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -17,7 +17,7 @@ function parseNums(obj, options) {
   for (key in obj) {
     if (obj.hasOwnProperty(key)) {
       value = obj[key];
-      parsedValue = options.parser.call(null, value, 10, key);
+      parsedValue = options.parser.call(null, value, 10);
 
       if (typeof value === 'string' && !options.protect(key) && !isNaN(parsedValue)) {
         result[key] = parsedValue;

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -24,13 +24,24 @@ var parser = require('../lib/parse');
 
 exports.parser = {
   setUp: function(done) {
+    var returnFalse = function () { return false };
+
     this.intOptions = {
-      parser: parseInt
+      parser: parseInt,
+      protect: returnFalse
     };
 
     this.floatOptions = {
-      parser: parseFloat
+      parser: parseFloat,
+      protect: returnFalse
     };
+
+    this.protectOptions = {
+      parser: parseInt,
+      protect: function (key) {
+        return key === 'id';
+      }
+    }
 
     done();
   },
@@ -104,6 +115,22 @@ exports.parser = {
         a: 'string'
       },
       'Should not convert regular string.'
+    );
+
+    test.done();
+  },
+
+  protect: function(test) {
+    test.deepEqual(
+      parser({
+        num: '12345',
+        id: '12345'
+      }, this.protectOptions),
+      {
+        num: 12345,
+        id: '12345'
+      },
+      'Should protect the given key.'
     );
 
     test.done();


### PR DESCRIPTION
I wasn't 100% happy with just passing in the key name to the parser function for a few reasons:
- The only use case is protecting a key from being parsed as an integer; there is no reason I can see to parse string --> integer differently based on its key.
- The parser function gets longer and less intuitive (I need to return `NaN` to protect a key from parsing?)
- We're passing in an extra argument to parseInt, which is weird.

I coded up an alternate way: a `protect` option for the parser. It's just a function that takes a key and returns `true` if it should be left as a string.

Comparison in JavaScript:

``` js
// Before
app.use(queryParser({
  parser: function (value, radix, key) {
    if (key === 'id') {
      return NaN;
    } else {
      return parseInt(value, radix);
    }
  }
}));

// After
app.use(queryParser({
  protect: function (key) {
    return key === 'id';
  }
}));
```

It also becomes a nice little one-liner in CoffeeScript:

``` coffeescript
# Before
app.use queryParser
  parser: (value, radix, key) ->
    if key is 'id' then NaN else parseInt(value, radix)

# After
app.use queryParser(protect: (key) -> key is 'id')
```

@crypti I'd love your take on this since I think it fits your use case really well. Feedback welcome :)
